### PR TITLE
Use existing class on profile options so icon will match

### DIFF
--- a/class.yagaunawardbadge.plugin.php
+++ b/class.yagaunawardbadge.plugin.php
@@ -63,7 +63,7 @@ class YagaUnawardBadgePlugin extends Gdn_Plugin {
         if(!C('Yaga.Badges.Enabled') || !CheckPermission('Yaga.Badges.Add')) return;
 
         $Sender->EventArguments['ProfileOptions'][] = array(
-            'Text' => Sprite('SpUnawardBadge', 'SpMod Sprite') . ' ' . T('Unaward Badges'),
+            'Text' => Sprite('SpAdminActivities SpNoBadge') . ' ' . T('Unaward Badges'),
             'Url' => '/profile/unawardbadges/'.$Sender->User->UserID.'/'.Gdn_Format::Url($Sender->User->Name)
         );
     }


### PR DESCRIPTION
This makes the sprites match up when the Sprites plugin is enabled.

Also have a specific class in case someone wants to do something special.
